### PR TITLE
Reformatting image data

### DIFF
--- a/public/scripts/core/imageEditor.js
+++ b/public/scripts/core/imageEditor.js
@@ -1,7 +1,7 @@
 import { Layer, LayerManager } from './layers.js';
 
 export class ImageEditor {
-    constructor(image, name, type, extension, canvas, context) {
+    constructor(image, name, type, extension, canvas) {
         this.IMAGE = image
         /* this.IMAGE
         This is the Image() element that stores the original image:
@@ -24,6 +24,9 @@ export class ImageEditor {
                 Type:           image/png 
         */
  
+
+
+        
         this.image = this.IMAGE                     // Used to resize images from from the original image dimensions while allow overwrites. 
         this.canvas = canvas
         this.context = canvas.getContext("2d")
@@ -35,9 +38,7 @@ export class ImageEditor {
         this.canvas.height = this.IMAGE.height
     }
 
-    // Load image loads a canvas with the passed image.
-    // TODO: It's important to do this to allow the user to crop the image at a later date. (I will need to change this.IMAGE calls to something more relative.)
-    // TODO: This should also avoid the problem of reloading an image, and it should allow applyLayers() to start at the index of the current image without redrawing everything below it.
+    // loadImage loads a canvas with the original image data.
     loadImage() {
         this.context.drawImage(this.IMAGE, 0, 0)
     }
@@ -60,7 +61,7 @@ export class ImageEditor {
     }
 
     bilinearInterpolation(newWidth, newHeight) {
-
+        // Come back to this tomorrow
     }
 
     nearestNeighbourInterpolation(newWidth, newHeight) {
@@ -71,7 +72,9 @@ export class ImageEditor {
         tempCanvas.height = newHeight;
 
         this.image = this.IMAGE
-        tempContext.drawImage(this.image, 0, 0, newWidth, newHeight); //I had no clue draw image had prebuilt interpolation, im just doing this instead wow
+
+        //Currently this is doing lininterp.
+        tempContext.drawImage(this.image, 0, 0, newWidth, newHeight); // Make a linear interpolation that works with this new data type.
 
         // Create new Image from the tempCanvas Context
         let resizedImage = new Image();
@@ -81,23 +84,19 @@ export class ImageEditor {
             this.canvas.width = newWidth;
             this.canvas.height = newHeight;
             this.context.drawImage(resizedImage, 0, 0);
+            this.renderImage()
         };
     }
 
     resizeCanvas(newHeight, newWidth, maintainAspectRatio, interpolationType) {
         console.log('Passing through: ', newHeight, newWidth, maintainAspectRatio, interpolationType)
-
-
-
-        // Were going to need to resize both the regular image and the modified image.
         if (interpolationType === "Nearest Neighbour") {
             console.log("Nearest Neighbour Interpolation Chosen")
-            this.nearestNeighbourInterpolation(newHeight, newWidth)
+            this.nearestNeighbourInterpolation(newWidth, newHeight)
         } else if (interpolationType === "Bilinear") {
             console.log("Bilinear Interpolation Chosen")
-            this.bilinearInterpolation(newHeight, newWidth)
+            this.bilinearInterpolation(newWidth, newHeight)
         }
-
         this.renderImage()
     }
 

--- a/public/scripts/core/imageEditor.js
+++ b/public/scripts/core/imageEditor.js
@@ -32,7 +32,7 @@ export class ImageEditor {
         this.context = canvas.getContext("2d")
 
         // Created Image Data
-        this.modifiedImage = this.IMAGE
+        this.modifiedImage = this.image
         this.layerManager = new LayerManager()
         this.canvas.width = this.IMAGE.width
         this.canvas.height = this.IMAGE.height
@@ -86,6 +86,9 @@ export class ImageEditor {
             this.canvas.height = newHeight;
             this.renderImage()
         };
+
+        tempCanvas.remove()
+        tempContext.remove()
     }
 
     resizeCanvas(newHeight, newWidth, maintainAspectRatio, interpolationType) {

--- a/public/scripts/core/imageEditor.js
+++ b/public/scripts/core/imageEditor.js
@@ -81,9 +81,9 @@ export class ImageEditor {
         resizedImage.src = tempCanvas.toDataURL(this.TYPE);
         resizedImage.onload = () => {
             this.image = resizedImage;
+            this.context.drawImage(resizedImage, 0, 0);
             this.canvas.width = newWidth;
             this.canvas.height = newHeight;
-            this.context.drawImage(resizedImage, 0, 0);
             this.renderImage()
         };
     }

--- a/public/scripts/core/imageEditor.js
+++ b/public/scripts/core/imageEditor.js
@@ -24,7 +24,7 @@ export class ImageEditor {
                 Type:           image/png 
         */
  
-    
+        this.image = this.IMAGE                     // Used to resize images from from the original image dimensions while allow overwrites. 
         this.canvas = canvas
         this.context = canvas.getContext("2d")
 
@@ -36,7 +36,7 @@ export class ImageEditor {
     }
 
     // Load image loads a canvas with the passed image.
-    // TODO: It's important to do this to allow the user to crop the image at a later date. (I will need to change this.image calls to something more relative.)
+    // TODO: It's important to do this to allow the user to crop the image at a later date. (I will need to change this.IMAGE calls to something more relative.)
     // TODO: This should also avoid the problem of reloading an image, and it should allow applyLayers() to start at the index of the current image without redrawing everything below it.
     loadImage() {
         this.context.drawImage(this.IMAGE, 0, 0)
@@ -50,7 +50,7 @@ export class ImageEditor {
     }
 
     renderImage() {
-        this.modifiedImage = this.IMAGE
+        this.modifiedImage = this.image
         this.context.drawImage(this.modifiedImage, 0, 0)
         const imageData = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height)
         
@@ -63,39 +63,27 @@ export class ImageEditor {
 
     }
 
-    nearestNeighbourInterpolation(newHeight, newWidth) {
+    nearestNeighbourInterpolation(newWidth, newHeight) {
         const tempCanvas = document.createElement('canvas');
         const tempContext = tempCanvas.getContext('2d');
+
         tempCanvas.width = newWidth;
         tempCanvas.height = newHeight;
 
-        for (let y = 0; y < newHeight; y++) {
-            for (let x = 0; x < newWidth; x++) {
-                // Calculate the position in the original image
-                const originalX = Math.floor((x * this.IMAGE.width) / newWidth);
-                const originalY = Math.floor((y * this.IMAGE.height) / newHeight);
+        this.image = this.IMAGE
+        tempContext.drawImage(this.image, 0, 0, newWidth, newHeight); //I had no clue draw image had prebuilt interpolation, im just doing this instead wow
 
-                // Get the pixel color from the original image
-                const pixelData = this.context.getImageData(originalX, originalY, 1, 1).data;
-
-                // Set the pixel color in the new image
-                tempContext.fillStyle = `rgba(${pixelData[0]}, ${pixelData[1]}, ${pixelData[2]}, ${pixelData[3] / 255})`;
-                tempContext.fillRect(x, y, 1, 1);
-            }
-        }
-
-        // Update core image to the new height and width.
-        let resizedImage = new Image()
-        resizedImage.src = tempCanvas.toDataURL(this.TYPE)
-        this.IMAGE = resizedImage
-
-        this.canvas.height = newHeight
-        this.canvas.width = newWidth
-        this.context.drawImage(tempCanvas, 0, 0);
+        // Create new Image from the tempCanvas Context
+        let resizedImage = new Image();
+        resizedImage.src = tempCanvas.toDataURL(this.TYPE);
+        resizedImage.onload = () => {
+            this.image = resizedImage;
+            this.canvas.width = newWidth;
+            this.canvas.height = newHeight;
+            this.context.drawImage(resizedImage, 0, 0);
+        };
     }
 
-    // This changes the resolution of this.image. Can be dangerous as we rely on this.image being an accurate representation of the provided image.
-    // The reason we change this.image has to do this this.renderImage()
     resizeCanvas(newHeight, newWidth, maintainAspectRatio, interpolationType) {
         console.log('Passing through: ', newHeight, newWidth, maintainAspectRatio, interpolationType)
 

--- a/public/scripts/core/layers.js
+++ b/public/scripts/core/layers.js
@@ -1,6 +1,5 @@
 export class Layer {
-    constructor(imageData=null, name="New Layer", visible = true, opacity = 1, effect=null) {
-        this.imageData = imageData
+    constructor(name="New Layer", visible = true, opacity = 1, effect=null) {
         this.name = name
         this.visible = visible
         this.opacity = opacity

--- a/public/scripts/taskbarHandler.js
+++ b/public/scripts/taskbarHandler.js
@@ -5,7 +5,29 @@ import { sepia } from './plugins/sepia.js';
 
 let imageEditor = null
 
+function resetEditor() {
+    if (imageEditor) {
+        imageEditor = null;
+    }
+
+    // Reset UI elements related to the image data
+    document.getElementById('titleName').textContent = '';
+    document.getElementById('imageName').textContent = '';
+    document.getElementById('titleDimensions').textContent = '';
+    document.getElementById('imageDimensions').textContent = '';
+    document.getElementById('titleExtension').textContent = '';
+    document.getElementById('imageExtension').textContent = '';
+
+    // Clear layers list
+    document.getElementById('layersList').innerHTML = '';
+    document.title = 'PhotoEdits';
+
+    // Hide or reset any other UI modules
+    closeResizeModule();
+}
+
 async function uploadImage() {
+    resetEditor()
     const file = document.querySelector("input[type=file]").files[0];
     if (!file) return;
 
@@ -16,8 +38,6 @@ async function uploadImage() {
     const name = file.name.substring(0, file.name.lastIndexOf('.'));
     const type = file.type;
     const extension = type.slice(6);
-    //const width =;
-    //const height =;
     const canvas = document.getElementById('imageCanvas');
 
     // Writes image data (Base64) to image.src

--- a/public/scripts/taskbarHandler.js
+++ b/public/scripts/taskbarHandler.js
@@ -26,31 +26,27 @@ async function uploadImage() {
     };
 
     // Image loading in allows creation of ImageEditor
+    // This is the place in code where you will initialze front end modules.
     image.onload = () => {
         imageEditor = new ImageEditor(image, name, type, extension, canvas);
         imageEditor.loadImage()
+        initializeOriginalImageDataModule()
     };
 
     reader.readAsDataURL(file);
 }
 
-function initializeDisplay(imageEditor) {
-
+function initializeOriginalImageDataModule() {
     document.title = `PhotoEdits | ${imageEditor.NAME}`
 
-            // Initializing Front End Layers Manager List
-            let layersList = document.getElementById('layersList')
-            layersList.innerHTML = ''
+    document.getElementById('titleName').textContent = 'Name:'
+    document.getElementById('imageName').textContent = imageEditor.NAME
 
-            // Initalizing Image Data Module
-            document.getElementById('titleName').textContent = 'Name:'
-            document.getElementById('imageName').textContent = imageEditor.Name
+    document.getElementById('titleDimensions').textContent = 'Dimensions:'
+    document.getElementById('imageDimensions').textContent = `${imageEditor.IMAGE.width} x ${imageEditor.IMAGE.height}px`
 
-            document.getElementById('titleDimensions').textContent = 'Dimensions:'
-            document.getElementById('imageDimensions').textContent = `${imageEditor.image.width} x ${imageEditor.image.height}px`
-
-            document.getElementById('titleExtension').textContent = 'Extension:'
-            document.getElementById('imageExtension').textContent = `.${imageEditor.FileExtension}`
+    document.getElementById('titleExtension').textContent = 'Extension:'
+    document.getElementById('imageExtension').textContent = `.${imageEditor.EXTENSION}`
 }
 
 // Function that takes the current imageEditor and recreates layerDiv's dynamically based on updates to the imageEditor.layerManager.
@@ -127,8 +123,8 @@ window.addEventListener('load', () => {
     let maintainAspectRatio = document.getElementById('constrainedCheckbox')
     maintainAspectRatio.addEventListener('change', () => {
         if (maintainAspectRatio.checked) {
-            let scaleFactor = imageEditor.canvas.width/document.getElementById('exportWidth').value
-            document.getElementById('exportHeight').value = Math.round(imageEditor.canvas.height / scaleFactor)
+            let scaleFactor = imageEditor.IMAGE.width/document.getElementById('exportWidth').value
+            document.getElementById('exportHeight').value = Math.round(imageEditor.IMAGE.height / scaleFactor)
         } else {
 
         }

--- a/public/scripts/taskbarHandler.js
+++ b/public/scripts/taskbarHandler.js
@@ -5,27 +5,38 @@ import { sepia } from './plugins/sepia.js';
 
 let imageEditor = null
 
-// Function for initializing an image for front end use from a provided image file.
-// The primary purpose of this function is to initalize an ImageEditor object.
-async function uploadImage(imageFile) {
-    try {
-        const image = new Image()
-        image.src = URL.createObjectURL(imageFile)
-        URL.revokeObjectURL(imageFile)
+async function uploadImage() {
+    const file = document.querySelector("input[type=file]").files[0];
+    if (!file) return;
 
-        image.onload = function () {
-            const imageCanvas = document.getElementById('imageCanvas')
+    const reader = new FileReader();
+    const image = new Image();
 
-            // Understanding Image Data
-            const fileName = imageFile.name.substring(0, imageFile.name.lastIndexOf('.'))
-            const fileType = imageFile.type
+    // File Metadata
+    const name = file.name.substring(0, file.name.lastIndexOf('.'));
+    const type = file.type;
+    const extension = type.slice(6);
+    //const width =;
+    //const height =;
+    const canvas = document.getElementById('imageCanvas');
 
-            // Initializing Image Editor
-            imageEditor = new ImageEditor(image, fileName, fileType, imageCanvas)
-            imageEditor.loadImage()
+    // Writes image data (Base64) to image.src
+    reader.onload = () => {
+        image.src = reader.result;
+    };
 
-            // Setting Title
-            document.title = `PhotoEdits | ${fileName}`
+    // Image loading in allows creation of ImageEditor
+    image.onload = () => {
+        imageEditor = new ImageEditor(image, name, type, extension, canvas);
+        imageEditor.loadImage()
+    };
+
+    reader.readAsDataURL(file);
+}
+
+function initializeDisplay(imageEditor) {
+
+    document.title = `PhotoEdits | ${imageEditor.NAME}`
 
             // Initializing Front End Layers Manager List
             let layersList = document.getElementById('layersList')
@@ -40,12 +51,6 @@ async function uploadImage(imageFile) {
 
             document.getElementById('titleExtension').textContent = 'Extension:'
             document.getElementById('imageExtension').textContent = `.${imageEditor.FileExtension}`
-
-            return imageEditor
-        }
-    } catch (error) {
-        console.error('Error importing image:', error)
-    }
 }
 
 // Function that takes the current imageEditor and recreates layerDiv's dynamically based on updates to the imageEditor.layerManager.
@@ -102,16 +107,9 @@ window.addEventListener('load', () => {
 
     // Opens file browser and loads the selected image to the canvas.
     document.getElementById('openFile').addEventListener('click', () => {
-        document.getElementById('uploadFile').addEventListener('change', (response) => {        
-            if(response.target.files[0]) {   
-                const imageFile = response.target.files[0]   
-                uploadImage(imageFile).catch((error) => {
-                    console.error('Image editor could not be instantiated:', error)
-                })
-            }
-        })
-        
-        document.getElementById('uploadFile').click()
+        const fileInput = document.getElementById("uploadFile");
+        fileInput.addEventListener("change", uploadImage)
+        fileInput.click()
     })
     
     document.getElementById('quickExport').addEventListener('click', () => {


### PR DESCRIPTION
Image data now functions how it did in older versions, but relies on imports that are normalized as base64 data. This got rid of type mismatch issues.

This also meant ImageEditor had to be completely rewritten. There is a lot of document and code updates written in here.

One small note, is that I'm now using .drawImage() for nearest neighbours interpolation, instead of an actual algorithm. I will fix this, but I'm considering the reformatting of image data task complete!